### PR TITLE
Add OS and architecture detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Go version manager.
 
+The `govsm` script automatically detects your operating system (Linux or macOS)
+and CPU architecture when downloading Go releases.
+
 ## Installation
 
 With `make` installed, run:
@@ -36,3 +39,4 @@ Run `govsm` without arguments to see the full help.
 
 - `curl` and `wget` installed
 - Permission to write to the installation directory
+- Works on Linux and macOS (architecture detected automatically)

--- a/govsm
+++ b/govsm
@@ -1,7 +1,34 @@
 #!/bin/bash
 
 INSTALL_DIR="/usr/local"
-GO_ARCH="linux-amd64"
+
+# Detect operating system and architecture
+detect_go_arch() {
+    local os=$(uname -s)
+    local arch=$(uname -m)
+
+    case "$os" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="darwin" ;;
+        *)
+            echo "Unsupported OS: $os"
+            exit 1
+            ;;
+    esac
+
+    case "$arch" in
+        x86_64|amd64) arch="amd64" ;;
+        arm64|aarch64) arch="arm64" ;;
+        *)
+            echo "Unsupported architecture: $arch"
+            exit 1
+            ;;
+    esac
+
+    echo "${os}-${arch}"
+}
+
+GO_ARCH="$(detect_go_arch)"
 
 list_versions() {
     echo "🔍 Fetching available versions..."


### PR DESCRIPTION
## Summary
- detect operating system and architecture in `govsm` script
- document automatic detection in README

## Testing
- `bash -n govsm`

------
https://chatgpt.com/codex/tasks/task_e_686991e81af0832bb3e39d4c6bf424b9